### PR TITLE
Filter "template" nodes

### DIFF
--- a/core-layout-grid.html
+++ b/core-layout-grid.html
@@ -47,6 +47,7 @@ TODO
             switch(node.localName) {
               case 'core-layout-grid':
               case 'style':
+              case 'template':
                 return false;
             }
             return true;


### PR DESCRIPTION
Filtering `template` nodes allows to use `core-layout-grid` inside a custom element that has it's children rendered through Polymer.

An use case could be something like this:

``` coffeescript
core-layout-grid
  template( repeat="{{item in items}}" )
    my-element( name="{{item.name}}" )
```
